### PR TITLE
add col class to op-json

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,7 +92,7 @@
 						<label for="docId">Document ID(optional)</label>
 				</div>
 
-				<div id="op-json" style="display: none" class="input-field"> <textarea name="json-input" class="materialize-textarea" style="font-family: Consolas, 'Courier New', Courier, monospace">
+				<div id="op-json" style="display: none" class="input-field col s12"> <textarea name="json-input" class="materialize-textarea" style="font-family: Consolas, 'Courier New', Courier, monospace">
 {
   someField: "fire",
   anotherOne: "pwn"


### PR DESCRIPTION
Without this, the op-json field was overlapping the input fields above it, preventing edits to those fields when the op-json field was display: block