### PR TITLE
Enable long-poll for proxies

### DIFF
--- a/lib/firebase-context.tsx
+++ b/lib/firebase-context.tsx
@@ -163,6 +163,11 @@ export function FirebaseProvider({ children }: { children: React.ReactNode }) {
       }
 
       w.firestoreService = firebase.firestore()
+      try {
+        w.firestoreService.settings({ experimentalForceLongPolling: true })
+      } catch (e) {
+        // Ignore settings error if they are already set
+      }
       w.authService = firebase.auth()
       w.functionsService = firebase.app().functions(effectiveRegion)
 


### PR DESCRIPTION
Certain proxies will break firestore, need to turn on "experimental" long polling. Was not able to get this new version running (was using the older firepwn regularly before). Debugging it lead me to this setting, i think its related to my vpn/proxy settings, but its a common hurdle. This PR fixes this issue.

ie: https://stackoverflow.com/questions/71045643/could-not-reach-cloud-firestore-backend-react-native-firebase-v9